### PR TITLE
FODCircleView:Dim_Behind Flag of Base View and set dim amount to 0.0f

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -315,7 +315,9 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
         mParams.type = WindowManager.LayoutParams.TYPE_DISPLAY_OVERLAY;
         mParams.flags = WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE |
                 WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN |
-                WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH;
+                WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED |
+                WindowManager.LayoutParams.FLAG_DIM_BEHIND |
+		WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH ;
         mParams.gravity = Gravity.TOP | Gravity.LEFT;
 
         mPressedParams.copyFrom(mParams);
@@ -324,6 +326,7 @@ public class FODCircleView extends ImageView implements TunerService.Tunable {
 
         mParams.setTitle("Fingerprint on display");
         mPressedParams.setTitle("Fingerprint on display.touched");
+	mParams.dimAmount = 0.0f;
 
         mPressedView = new ImageView(context)  {
             @Override


### PR DESCRIPTION
This will fix problem onTouch of apparently boost brightness for xiaomi sm8250 fod implementation.
This will not fix totally the problem, if into lineage fod hal implementation write on disp_param command to enable fod_hbm display function, to solve need concomitant use of composition engine.