### PR TITLE
SystemUI: Unblock gestural navigation on clearScreenshot()

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/screenshot/GlobalScreenshot.java
+++ b/packages/SystemUI/src/com/android/systemui/screenshot/GlobalScreenshot.java
@@ -416,7 +416,9 @@ public class GlobalScreenshot implements ViewTreeObserver.OnComputeInternalInset
 
     void hideScreenshotSelector() {
         setLockedScreenOrientation(false);
-        mWindowManager.removeView(mScreenshotLayout);
+        if (mScreenshotLayout.getWindowToken() != null) {
+            mWindowManager.removeView(mScreenshotLayout);
+        }
         mScreenshotSelectorView.stopSelection();
         mScreenshotSelectorView.setVisibility(View.GONE);
         mCaptureButton.setVisibility(View.GONE);
@@ -1234,6 +1236,7 @@ public class GlobalScreenshot implements ViewTreeObserver.OnComputeInternalInset
         mActionsContainer.setTranslationY(0);
         mActionsContainerBackground.setTranslationY(0);
         mScreenshotPreview.setTranslationY(0);
+        hideScreenshotSelector();
     }
 
     private void setAnimatedViewSize(int width, int height) {


### PR DESCRIPTION
If user powers screen off when partial screenshot UI is visible,
it will hide the UI but leave gestural navigation disabled.
Also the partial screenshot UI would be visible when taking a
new (normal) screenshot.

Change-Id: Ie8138bb0b771ec0e21ceb48e52872c05c946d3b4