### PR TITLE
HACK: telephony: Conditionally force enable LTE_CA

### DIFF
--- a/telephony/java/android/telephony/NetworkRegistrationInfo.java
+++ b/telephony/java/android/telephony/NetworkRegistrationInfo.java
@@ -27,6 +27,7 @@ import android.compat.annotation.EnabledSince;
 import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.os.SystemProperties;
 import android.telephony.AccessNetworkConstants.TransportType;
 import android.telephony.Annotation.NetworkType;
 import android.text.TextUtils;
@@ -640,6 +641,11 @@ public final class NetworkRegistrationInfo implements Parcelable {
      * @hide
      */
     public void setAccessNetworkTechnology(@NetworkType int tech) {
+	// HACK: Force LTE Carrier Aggregation
+        if (SystemProperties.getBoolean("persist.sys.radio.force_lte_ca", false)
+                && tech == TelephonyManager.NETWORK_TYPE_LTE) {
+            mIsUsingCarrierAggregation = true;
+        }
         if (tech == TelephonyManager.NETWORK_TYPE_LTE_CA) {
             // For old device backward compatibility support
             tech = TelephonyManager.NETWORK_TYPE_LTE;


### PR DESCRIPTION
Implementation of Force LTE CA in Network Carrier Settings 

"Apparently since S LTE_CA is not properly working, let's conditionally force enable it until a proper solution is found."